### PR TITLE
fix: map CC spine01/02 (#112)

### DIFF
--- a/src/glb-canonicalize.js
+++ b/src/glb-canonicalize.js
@@ -441,6 +441,13 @@ function _lookupBone(name) {
 	// tables below. Without this an entire CC export maps zero bones and lands in
 	// a bind-pose T-pose.
 	s = s.replace(/^CC_Base_/i, '');
+	// Reallusion CC3/CC4 numbered spine: CC_Base_Spine01/02 -> Spine01/02 after strip.
+	// Unlike Unreal's spine_01 (spine02 collides with Mixamo Spine+_02 dedup), Spine01
+	// has no separator before digits, so we handle it explicitly before the general
+	// alias table to avoid colliding with Mixamo's `Spine_02` dedup (which normalizes
+	// to spine02 but should dedup to Spine, not Spine1). CC has Hips + 2 spine joints.
+	if (/^spine01$/i.test(s)) return 'Spine';
+	if (/^spine02$/i.test(s)) return 'Spine1';
 	// Sketchfab / Maya joint exports prefix every joint `j_` (`j_pelvis`, `j_L_hip`,
 	// `j_spine_0`). Stripping it leaves stems the canonical + sided tables resolve.
 	// The negative lookahead protects VRM/VRoid, whose `J_Bip_*` / `J_Sec_*` names


### PR DESCRIPTION
Fixes #112. `CC_Base_Spine01`/`CC_Base_Spine02` (Reallusion CC3/CC4) were not mapped, causing entire CC rig to fall through to bind-pose.

### Problem
- `src/glb-canonicalize.js:444` comment says CC prefix is stripped, but `Spine01`/`Spine02` (no separator) had no alias, so `CC_Base_Spine01` → `Spine01` → `spine01` → `null`.
- Adding `['spine01','Spine']`/`['spine02','Spine1']` to `EXTRA_ALIASES` collides with Mixamo's `Spine_02` dedup (`Spine_02` → dedup `Spine` → `Spine`, but `spine_02` normalizes to `spine02` and would incorrectly hit `Spine1`).

### Solution
`src/glb-canonicalize.js:444-450` — handle `Spine01`/`Spine02` explicitly before the general alias table, after `CC_Base_` strip:

```js
s = s.replace(/^CC_Base_/i, '');
// Reallusion CC3/CC4 numbered spine: CC_Base_Spine01/02 -> Spine01/02 after strip.
// Unlike Unreal's spine_01 (spine02 collides with Mixamo Spine+_02 dedup), Spine01
// has no separator before digits, so we handle it explicitly before the general
// alias table to avoid colliding with Mixamo's `Spine_02` dedup (which normalizes
// to spine02 but should dedup to Spine, not Spine1).
if (/^spine01$/i.test(s)) return 'Spine';
if (/^spine02$/i.test(s)) return 'Spine1';
```

- `CC_Base_Spine01` → `Spine01` → `Spine`
- `CC_Base_Spine02` → `Spine02` → `Spine1`
- `spine01`/`spine02` without prefix also map correctly
- `Spine_02`/`mixamorig:Spine_02` still dedup to `Spine` (not `Spine1`) — preserves existing test `expect(canonicalizeBoneName('mixamorig:Spine_02')).toBe('Spine')`

### Verification (folder-local, no global installs)
- Cloned file via `raw.githubusercontent.com` to `C:\Users\Azelf\AppData\Local\Temp\opencode\three-ws-minimal` (full clone timed out due to large assets, used minimal folder)
- `npm init -y`, `npm install three` (folder-local), `npm pkg set type=module`
- `node test.mjs`:
  - `CC_Base_Spine01` → `Spine` ✓
  - `CC_Base_Spine02` → `Spine1` ✓
  - `spine01` → `Spine` ✓
  - `spine02` → `Spine1` ✓
  - `mixamorig:Spine_02` → `Spine` ✓ (regression)
  - `spine_02` → `Spine` ✓
  - `CC_Base_Hip` → `Hips` ✓
- No `npm install -g`, no `pip`, just folder-local `node`.

Stars: **105★** (not zero), 7 open issues, updated 2026.

Closes #112
