### PR TITLE
test: guard rig convention docs drift

### DIFF
--- a/src/rig-report.js
+++ b/src/rig-report.js
@@ -72,7 +72,7 @@ export const LIMB_GROUPS = Object.freeze([
 // `schema` maps onto the avatar-manifest `skeleton` enum
 // (packages/avatar-schema/schema/avatar.v1.json), so the generated manifest
 // declares the right value instead of defaulting everything to `custom`.
-const CONVENTIONS = [
+export const CONVENTIONS = [
 	{
 		id: 'rpm', label: 'Ready Player Me', schema: 'rpm',
 		test: (ctx) => ctx.meshNames.some((n) => /^Wolf3D_/i.test(n)) && ctx.joints.some((n) => /Hips$/i.test(n)),

--- a/tests/rig-report.test.js
+++ b/tests/rig-report.test.js
@@ -16,6 +16,7 @@ import {
 	MIN_CANONICAL_BONES,
 	CANONICAL_TOTAL,
 	LIMB_GROUPS,
+	CONVENTIONS,
 } from '../src/rig-report.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -27,6 +28,17 @@ function load(name) {
 
 function report(name) {
 	return analyzeGlb(load(name), { fileName: `${name}.glb` });
+}
+
+function documentedRigConventions() {
+	const doc = readFileSync(join(ROOT, 'docs/rig-doctor.md'), 'utf8');
+	const rows = [];
+	for (const match of doc.matchAll(/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*`([^`]+)`\s*\|$/gm)) {
+		const convention = match[1].trim();
+		if (convention === 'Convention' || /^-+$/.test(convention)) continue;
+		rows.push({ convention, detectedBy: match[2].trim(), schema: match[3].trim() });
+	}
+	return rows;
 }
 
 describe('readGlbJson', () => {
@@ -54,6 +66,19 @@ describe('readGlbJson', () => {
 
 describe('detectConvention fingerprints', () => {
 	const ctx = (joints, meshNames = []) => ({ joints, meshNames, json: {} });
+
+	it('keeps documented rig conventions in sync with the detector', () => {
+		const implemented = CONVENTIONS.filter((c) => c.id !== 'unknown');
+		const docs = documentedRigConventions();
+		const implementedLabels = implemented.map((c) => c.label);
+		const documentedLabels = docs.map((row) => row.convention);
+
+		expect(documentedLabels).toEqual(implementedLabels);
+		for (const convention of implemented) {
+			expect(convention.evidence, `${convention.label} evidence`).toEqual(expect.any(String));
+			expect(convention.evidence.trim(), `${convention.label} evidence`).not.toBe('');
+		}
+	});
 
 	it('identifies an MMD rig from its Japanese PMX bone names', () => {
 		const c = detectConvention(ctx(['センター', '上半身', '左腕', '左ひじ', '右ひざ']));


### PR DESCRIPTION
## What & why

Adds a mechanical drift guard for the Rig Doctor convention list.

Closes #114

The test reads the recognised rig conventions table from `docs/rig-doctor.md` and compares its convention labels to the detector's exported `CONVENTIONS` list. It also asserts every implemented convention has non-empty user-facing `evidence` text.

## Type of change

- [ ] Feature
- [ ] Improvement
- [ ] Fix
- [ ] Docs
- [x] Infra / chore (no user-visible effect)

## Definition of done

- [x] Code is fully wired and reachable by the user — no dead paths, stubs, TODOs, or commented-out code.
- [x] No mocks, fake data, or placeholder values — real APIs and real data only.
- [ ] Every interactive element has hover, active, and focus states (UI changes).
- [ ] Loading, empty, and error states are designed and helpful (UI changes).
- [ ] `npm test` passes and `npm run typecheck` is clean.
- [ ] `npm run lint` is clean (or only pre-existing warnings).
- [x] I reviewed my own `git diff` — every changed line is justified.

## Verification

- `npx vitest run tests/rig-report.test.js` — 22 tests passed.
- Drift proof: temporarily removed the `Mixamo` row from `docs/rig-doctor.md`; `npx vitest run tests/rig-report.test.js` failed with `expected [ 'Ready Player Me', …(10) ] to deeply equal [ 'Ready Player Me', 'Mixamo', …(10) ]`; restored the row and reran the focused suite successfully.
- `npm run typecheck` currently fails on unrelated existing errors in `api/_lib/brownout/provenance.js`, `api/_lib/ops/x402-settle-health.js`, `api/_lib/sniper-solvency.js`, and `api/_lib/upstream-fetch.js`.
- `npm run lint -- --quiet` currently fails on unrelated existing errors in `packages/metaplex-agent-mcp/docs/app.js` and `src/categories.js`.

## Changelog

- [x] Added a `data/changelog.json` entry, **or** this change is internal-only and needs none.

## Screenshots / recordings

Not applicable; test-only change.
